### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ but I make no real claims beyond that. If you use it you will almost certainly
 run into problems.
 
 The concept here is as follows: Suppose we want to test something by throwing
-random data at it, e.g. using `Hypothesis <http://hypothesis.readthedocs.org>`_,
+random data at it, e.g. using `Hypothesis <https://hypothesis.readthedocs.io>`_,
 but the subset of the data we do anything useful with is extremely finicky
 and we don't have a good handle on what a useful distribution would be.
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
